### PR TITLE
Fix alignment improperly being applied to typedefs

### DIFF
--- a/lib/blake2.c
+++ b/lib/blake2.c
@@ -50,7 +50,7 @@
     uint8_t  personal[BLAKE2S_PERSONALBYTES];  // 32
   } blake2s_param;
 
-  ALIGN( 64 ) typedef struct __blake2s_state
+typedef struct ALIGN( 64 ) __blake2s_state
   {
     uint32_t h[8];
     uint32_t t[2];
@@ -75,7 +75,7 @@
     uint8_t  personal[BLAKE2B_PERSONALBYTES];  // 64
   } blake2b_param;
 
-  ALIGN( 64 ) typedef struct __blake2b_state
+typedef struct ALIGN( 64 ) __blake2b_state
   {
     uint64_t h[8];
     uint64_t t[2];


### PR DESCRIPTION
The alignment is improperly being applied to the typedef which causes the alignment of `struct __blake2b_state` to not match the alignment of `blake2b_state`. This will fail starting with GCC 11.